### PR TITLE
Fix security vulnerabilities in dependencies by removing checkstyle plugin from main dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
   </modules>
 
   <properties>
-    <cdap.version>6.9.1</cdap.version>
-    <slf4j.version>1.5.6</slf4j.version>
+    <cdap.version>6.11.1</cdap.version>
+    <slf4j.version>1.7.36</slf4j.version>
   </properties>
 
   <dependencies>
@@ -74,29 +74,16 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-checkstyle-plugin</artifactId>
-      <version>2.17</version>
-      <type>maven-plugin</type>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
**Goal:** Resolve dependency security vulnerabilities, bump CDAP version compatibility, and upgrade outdated logging libraries.

#### Key Changes:
1. **Vulnerability Resolution**: Removed the `maven-checkstyle-plugin` from the parent POM `<dependencies>` block. This plugin was mistakenly declared as a runtime dependency, pulling in all 7 flagged transitive vulnerabilities (`checkstyle`, `commons-collections`, `commons-io`, `jackrabbit`, `maven-core`, `maven-shared-utils`, and `plexus-utils`).
2. **CDAP Version Bump**: Updated `<cdap.version>` to `6.11.1` to align with modern GKE and remote repository compatibility.
3. **SLF4J Logging Upgrade**: Upgraded `slf4j-api` and `slf4j-simple` versions to `1.7.36` and marked `slf4j-api` as `<scope>provided</scope>` to avoid classloader conflicts and match GDF hosting standards.

#### Verification:
* Compiles and passes all local checks (`mvn clean package` passes checkstyle validation and tests successfully with 0 failures/errors).
* Deployed and verified end-to-end inside GKE, successfully capturing pipeline status transition event payloads pulled from Pub/Sub.